### PR TITLE
Adds z-index as configurable option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ import curDot from 'cursor-dot'
 const cursor = curDot()
 // or, set as you want
 // cursor({
+//   zIndex: 2,
 //   diameter: 80,
 //   borderWidth: 1,
 //   borderColor: 'transparent',

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const isEl = obj => obj instanceof HTMLElement
 const isStr = obj => Object.prototype.toString.call(obj) === '[object String]'
 
 const cursorDot = ({
+  zIndex = 1,
   diameter = 80,
   borderWidth = 1,
   borderColor = '#fff',
@@ -17,7 +18,7 @@ const cursorDot = ({
   const cur = { x: 0, y: 0, o: 0, d: diameter }
   const dot = document.createElement('div')
   const tim = easing / 15
-  dot.style = `position:fixed;top:0;left:0;border-radius:100%;pointer-events:none;opacity:0;height:${diameter}px;width:${diameter}px;background:${background};border:${borderWidth}px solid ${borderColor};mix-blend-mode:exclusion;transition:background ${tim}s,border ${tim}s`
+  dot.style = `position:fixed;top:0;left:0;border-radius:100%;pointer-events:none;opacity:0;z-index:${zIndex};height:${diameter}px;width:${diameter}px;background:${background};border:${borderWidth}px solid ${borderColor};mix-blend-mode:exclusion;transition:background ${tim}s,border ${tim}s`
 
   document.addEventListener('mousemove', e => {
     alt.x = e.clientX


### PR DESCRIPTION
I was having issues where my cursor was going behind menus and inline images in a Gatsby.js build and thought: why isn't z-index a configurable option? This sets the default value at 1, so if that needs changed, I understand, but I do like having it as a configurable option.

I also updated the README.md with this configurable option.